### PR TITLE
Fix INA237/238 ReadPower Method

### DIFF
--- a/Adafruit_INA237.cpp
+++ b/Adafruit_INA237.cpp
@@ -190,9 +190,9 @@ float Adafruit_INA237::readCurrent(void) {
 /**************************************************************************/
 float Adafruit_INA237::readPower(void) {
   Adafruit_I2CRegister power =
-      Adafruit_I2CRegister(i2c_dev, INA2XX_REG_POWER, 2, MSBFIRST);
-  // INA237 power LSB = 20 * current_lsb
-  return (float)power.read() * 20.0 * _current_lsb * 1000.0; // Convert W to mW
+      Adafruit_I2CRegister(i2c_dev, INA2XX_REG_POWER, 3, MSBFIRST);
+  // INA237 power LSB = 0.2 * current_lsb
+  return (float)power.read() * 0.2 * _current_lsb * 1000.0; // Convert W to mW
 }
 
 /**************************************************************************/


### PR DESCRIPTION
The Power register is 3 bytes wide, rather than 2.  Also the datasheet has a multiplier of 0.2x rather than 20x.

From INA238 datasheet: 
<img width="777" height="529" alt="image" src="https://github.com/user-attachments/assets/9bfbd008-5fb3-4355-acb1-4c84097a62ee" />
<img width="1896" height="589" alt="image" src="https://github.com/user-attachments/assets/42581b6d-3c96-40c6-b757-365645684439" />

From Section 7.1.2 of the INA238 Datasheet:
<img width="2081" height="574" alt="image" src="https://github.com/user-attachments/assets/fc116ebd-f9ae-44df-b513-b322363c7599" />
